### PR TITLE
Add namespace support

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,19 +4,58 @@ const fp = require('fastify-plugin')
 const RedisMock = require('ioredis-mock')
 
 function fastifyRedisMock (fastify, options, next) {
-  var client = options.client || null
+  const { namespace, url, ...redisOptions } = options
+  let client = options.client || null
 
-  if (!client) {
-    try {
-      client = new RedisMock(options)
-    } catch (err) {
-      return next(err)
+  if (namespace) {
+    if (!fastify.redis) {
+      fastify.decorate('redis', {})
+    }
+
+    if (fastify.redis[namespace]) {
+      return next(new Error(`Redis '${namespace}' instance namespace has already been registered`))
+    }
+
+    const closeNamedInstance = (fastify, done) => {
+      fastify.redis[namespace].quit(done)
+    }
+
+    if (!client) {
+      try {
+        client = new RedisMock(redisOptions)
+      } catch (err) {
+        return next(err)
+      }
+
+      fastify.addHook('onClose', closeNamedInstance)
+    }
+
+    fastify.redis[namespace] = client
+
+    if (options.closeClient === true) {
+      fastify.addHook('onClose', closeNamedInstance)
+    }
+  } else {
+    if (fastify.redis) {
+      return next(new Error('fastify-redis has already been registered'))
+    } else {
+      if (!client) {
+        try {
+          client = new RedisMock(redisOptions)
+        } catch (err) {
+          return next(err)
+        }
+
+        fastify.addHook('onClose', close)
+      }
+
+      fastify.decorate('redis', client)
+
+      if (options.closeClient === true) {
+        fastify.addHook('onClose', close)
+      }
     }
   }
-
-  fastify
-    .decorate('redis', client)
-    .addHook('onClose', close)
 
   next()
 }

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   },
   "homepage": "https://github.com/Rubendewit/fastify-redis-mock#readme",
   "devDependencies": {
-    "fastify": "^1.9.0",
-    "standard": "12.0.1",
-    "tap": "^12.0.1"
+    "fastify": "^3.18.1",
+    "standard": "^16.0.3",
+    "tap": "^15.0.9"
   },
   "dependencies": {
-    "fastify-plugin": "^1.2.0",
-    "ioredis": "^4.0.0",
-    "ioredis-mock": "^3.14.3"
+    "fastify-plugin": "^3.0.0",
+    "ioredis": "^4.27.6",
+    "ioredis-mock": "^5.6.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -5,27 +5,26 @@ const test = t.test
 const Fastify = require('fastify')
 const fastifyRedis = require('./index')
 
-t.beforeEach(done => {
+t.beforeEach(async () => {
   const fastify = Fastify()
 
-  fastify.register(fastifyRedis)
-
-  fastify.ready(err => {
-    t.error(err)
-
-    fastify.redis.flushall(() => {
-      fastify.close()
-      done()
-    })
+  fastify.register(fastifyRedis, {
+    host: '127.0.0.1'
   })
+
+  await fastify.ready()
+  await fastify.redis.flushall()
+  await fastify.close()
 })
 
-test('fastify.redis should exist', t => {
+test('fastify.redis should exist', (t) => {
   t.plan(2)
   const fastify = Fastify()
-  fastify.register(fastifyRedis)
+  fastify.register(fastifyRedis, {
+    host: '127.0.0.1'
+  })
 
-  fastify.ready(err => {
+  fastify.ready((err) => {
     t.error(err)
     t.ok(fastify.redis)
 
@@ -33,16 +32,18 @@ test('fastify.redis should exist', t => {
   })
 })
 
-test('fastify.redis should be the redis client', t => {
+test('fastify.redis should be the redis client', (t) => {
   t.plan(4)
   const fastify = Fastify()
 
-  fastify.register(fastifyRedis)
+  fastify.register(fastifyRedis, {
+    host: '127.0.0.1'
+  })
 
-  fastify.ready(err => {
+  fastify.ready((err) => {
     t.error(err)
 
-    fastify.redis.set('key', 'value', err => {
+    fastify.redis.set('key', 'value', (err) => {
       t.error(err)
       fastify.redis.get('key', (err, val) => {
         t.error(err)
@@ -54,23 +55,270 @@ test('fastify.redis should be the redis client', t => {
   })
 })
 
-test('promises support', t => {
+test('fastify.redis.test namespace should exist', (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  fastify.register(fastifyRedis, {
+    host: '127.0.0.1',
+    namespace: 'test'
+  })
+
+  fastify.ready((err) => {
+    t.error(err)
+    t.ok(fastify.redis)
+    t.ok(fastify.redis.test)
+
+    fastify.close()
+  })
+})
+
+test('fastify.redis.test should be the redis client', (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifyRedis, {
+    host: '127.0.0.1',
+    namespace: 'test'
+  })
+
+  fastify.ready((err) => {
+    t.error(err)
+
+    fastify.redis.test.set('key_namespace', 'value_namespace', (err) => {
+      t.error(err)
+      fastify.redis.test.get('key_namespace', (err, val) => {
+        t.error(err)
+        t.equal(val, 'value_namespace')
+
+        fastify.close()
+      })
+    })
+  })
+})
+
+test('promises support', (t) => {
   t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifyRedis)
+  fastify.register(fastifyRedis, {
+    host: '127.0.0.1'
+  })
 
-  fastify.ready(err => {
+  fastify.ready((err) => {
     t.error(err)
 
-    fastify.redis.set('key', 'value')
+    fastify.redis
+      .set('key', 'value')
       .then(() => {
         return fastify.redis.get('key')
       })
-      .then(val => {
+      .then((val) => {
         t.equal(val, 'value')
         fastify.close()
       })
-      .catch(err => t.fail(err))
+      .catch((err) => t.fail(err))
+  })
+})
+
+test('custom client', (t) => {
+  t.plan(7)
+  const fastify = Fastify()
+  const RedisMock = require('ioredis-mock')
+  const redis = new RedisMock({ host: 'localhost', port: 6379 })
+
+  fastify.register(fastifyRedis, { client: redis })
+
+  fastify.ready((err) => {
+    t.error(err)
+    t.equal(fastify.redis, redis)
+
+    fastify.redis.set('key', 'value', (err) => {
+      t.error(err)
+      fastify.redis.get('key', (err, val) => {
+        t.error(err)
+        t.equal(val, 'value')
+
+        fastify.close(function (err) {
+          t.error(err)
+          fastify.redis.quit(function (err) {
+            t.error(err)
+          })
+        })
+      })
+    })
+  })
+})
+
+test('custom client gets closed', (t) => {
+  t.plan(7)
+  const fastify = Fastify()
+  const RedisMock = require('ioredis-mock')
+  const redis = new RedisMock({ host: 'localhost', port: 6379 })
+
+  fastify.register(fastifyRedis, { client: redis, closeClient: true })
+
+  fastify.ready((err) => {
+    t.error(err)
+    t.equal(fastify.redis, redis)
+
+    fastify.redis.set('key', 'value', (err) => {
+      t.error(err)
+      fastify.redis.get('key', (err, val) => {
+        t.error(err)
+        t.equal(val, 'value')
+
+        const origQuit = fastify.redis.quit
+        fastify.redis.quit = (cb) => {
+          t.pass('redis client closed')
+          origQuit.call(fastify.redis, cb)
+        }
+
+        fastify.close(function (err) {
+          t.error(err)
+        })
+      })
+    })
+  })
+})
+
+test('custom client inside a namespace', (t) => {
+  t.plan(7)
+  const fastify = Fastify()
+  const RedisMock = require('ioredis-mock')
+  const redis = new RedisMock({ host: 'localhost', port: 6379 })
+
+  fastify.register(fastifyRedis, {
+    namespace: 'test',
+    client: redis
+  })
+
+  fastify.ready((err) => {
+    t.error(err)
+    t.equal(fastify.redis.test, redis)
+
+    fastify.redis.test.set('key', 'value', (err) => {
+      t.error(err)
+      fastify.redis.test.get('key', (err, val) => {
+        t.error(err)
+        t.equal(val, 'value')
+
+        fastify.close(function (err) {
+          t.error(err)
+          fastify.redis.test.quit(function (err) {
+            t.error(err)
+          })
+        })
+      })
+    })
+  })
+})
+
+test('custom client inside a namespace gets closed', (t) => {
+  t.plan(7)
+  const fastify = Fastify()
+  const RedisMock = require('ioredis-mock')
+  const redis = new RedisMock({ host: 'localhost', port: 6379 })
+
+  fastify.register(fastifyRedis, {
+    namespace: 'test',
+    client: redis,
+    closeClient: true
+  })
+
+  fastify.ready((err) => {
+    t.error(err)
+    t.equal(fastify.redis.test, redis)
+
+    fastify.redis.test.set('key', 'value', (err) => {
+      t.error(err)
+      fastify.redis.test.get('key', (err, val) => {
+        t.error(err)
+        t.equal(val, 'value')
+
+        const origQuit = fastify.redis.test.quit
+        fastify.redis.test.quit = (cb) => {
+          t.pass('redis client closed')
+          origQuit.call(fastify.redis.test, cb)
+        }
+
+        fastify.close(function (err) {
+          t.error(err)
+        })
+      })
+    })
+  })
+})
+
+test('fastify.redis.test should throw with duplicate connection namespaces', (t) => {
+  t.plan(1)
+
+  const namespace = 'test'
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify
+    .register(fastifyRedis, {
+      host: '127.0.0.1',
+      namespace
+    })
+    .register(fastifyRedis, {
+      host: '127.0.0.1',
+      namespace
+    })
+
+  fastify.ready((err) => {
+    t.equal(err.message, `Redis '${namespace}' instance namespace has already been registered`)
+  })
+})
+
+test('Should throw when trying to register multiple instances without giving a namespace', (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify
+    .register(fastifyRedis, {
+      host: '127.0.0.1'
+    })
+    .register(fastifyRedis, {
+      host: '127.0.0.1'
+    })
+
+  fastify.ready((err) => {
+    t.equal(err.message, 'fastify-redis has already been registered')
+  })
+})
+
+test('Should not throw within different contexts', (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify.register(function (instance, options, next) {
+    instance.register(fastifyRedis, {
+      host: '127.0.0.1'
+    })
+    next()
+  })
+
+  fastify.register(function (instance, options, next) {
+    instance
+      .register(fastifyRedis, {
+        host: '127.0.0.1',
+        namespace: 'test1'
+      })
+      .register(fastifyRedis, {
+        host: '127.0.0.1',
+        namespace: 'test2'
+      })
+    next()
+  })
+
+  fastify.ready((error) => {
+    t.error(error)
   })
 })


### PR DESCRIPTION
Add support for `namespace` similar to `fastify-redis` so you can register multiple Redis client instances (like [here](https://github.com/fastify/fastify-redis#registering-multiple-redis-client-instances)).